### PR TITLE
Fix mail-parser Decoding issue, enabling ipaddress package for python…

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -478,11 +478,6 @@
     github = "asppsa";
     name = "Alastair Pharo";
   };
-  psyanticy = {
-    email = "iuns@outlook.fr";
-    github = "Assassinkin";
-    name = "Psyanticy";
-  };
   astsmtl = {
     email = "astsmtl@yandex.ru";
     github = "astsmtl";
@@ -3025,6 +3020,11 @@
   pstn = {
     email = "philipp@xndr.de";
     name = "Philipp Steinpaß";
+  };
+  psyanticy = {
+    email = "iuns@outlook.fr";
+    github = "Assassinkin";
+    name = "Psyanticy";
   };
   puffnfresh = {
     email = "brian@brianmckenna.org";

--- a/pkgs/development/python-modules/mail-parser/default.nix
+++ b/pkgs/development/python-modules/mail-parser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, buildPythonPackage, fetchPypi, ipaddress, six, simplejson }:
+{ stdenv, pkgs, buildPythonPackage, glibcLocales, fetchPypi, ipaddress, six, simplejson }:
 
 buildPythonPackage rec {
   pname = "mail-parser";
@@ -9,7 +9,13 @@ buildPythonPackage rec {
     sha256 = "0w8hwcld67j6hqzjycbbqk6pvsjpg0a5si6fzzdhzdh7h55y6gd9";
   };
 
+  LC_ALL = "en_US.utf-8";
+
+  nativeBuildInputs = [ glibcLocales ];
   propagatedBuildInputs = [ ipaddress six simplejson ];
+
+  # No tests in the archive downloaded using fetchPypi
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "A mail parser for python 2 and 3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6701,7 +6701,7 @@ in {
     };
   };
 
-  ipaddress = if (pythonAtLeast "3.3") then null else buildPythonPackage rec {
+  ipaddress = buildPythonPackage rec {
     name = "ipaddress-1.0.18";
 
     src = pkgs.fetchurl {


### PR DESCRIPTION
… 3.3 and nerwer versions.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

